### PR TITLE
Travis CI cache fix, muldiv include

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 before_script:
   - cd formal
-  - if ($TRAVIS_PULL_REQUEST_SLUG); then export BUILD_PATH=$TRAVIS_PULL_REQUEST_SLUG; else export BUILD_PATH=$TRAVIS_REPO_SLUG; fi
+  - if ("$TRAVIS_PULL_REQUEST"); then export BUILD_PATH=$TRAVIS_PULL_REQUEST_SLUG; else export BUILD_PATH=$TRAVIS_REPO_SLUG; fi
 script:
   # Run riscv-formal for WARP-V.
   - PATH=/home/travis/build/$BUILD_PATH/formal/env/bin:$PATH bash -c 'make verif';

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ language: generic
 
 cache:
   directories:
-    /home/travis/build/stevehoover/warp-v/formal/env
+    if ($TRAVIS_PULL_REQUEST); then /home/travis/build/$TRAVIS_PULL_REQUEST_SLUG/formal/env;
+    else /home/travis/build/$TRAVIS_REPO_SLUG/formal/env; fi
 
 before_install:
 install:
@@ -21,7 +22,8 @@ before_script:
   - cd formal
 script:
   # Run riscv-formal for WARP-V.
-  - PATH=/home/travis/build/stevehoover/warp-v/formal/env/bin:$PATH bash -c 'make verif'
+  - if ($TRAVIS_PULL_REQUEST); then PATH=/home/travis/build/$TRAVIS_PULL_REQUEST_SLUG/formal/env/bin:$PATH bash -c 'make verif'; 
+    else PATH=/home/travis/build/$TRAVIS_REPO_SLUG/formal/env/bin:$PATH bash -c 'make verif';
 after_success:
 after_failure:
   # Upload files for debug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ language: generic
 
 cache:
   directories:
-    if ($TRAVIS_PULL_REQUEST); then /home/travis/build/$TRAVIS_PULL_REQUEST_SLUG/formal/env;
-    else /home/travis/build/$TRAVIS_REPO_SLUG/formal/env; fi
+    -  /home/travis/build/$TRAVIS_PULL_REQUEST_SLUG/formal/env
+    -  /home/travis/build/$TRAVIS_REPO_SLUG/formal/env
 
 before_install:
 install:
@@ -20,14 +20,14 @@ install:
 
 before_script:
   - cd formal
+  - if ($TRAVIS_PULL_REQUEST_SLUG); then export BUILD_PATH=$TRAVIS_PULL_REQUEST_SLUG; else export BUILD_PATH=$TRAVIS_REPO_SLUG; fi
 script:
   # Run riscv-formal for WARP-V.
-  - if ($TRAVIS_PULL_REQUEST); then PATH=/home/travis/build/$TRAVIS_PULL_REQUEST_SLUG/formal/env/bin:$PATH bash -c 'make verif'; 
-    else PATH=/home/travis/build/$TRAVIS_REPO_SLUG/formal/env/bin:$PATH bash -c 'make verif';
+  - PATH=/home/travis/build/$BUILD_PATH/formal/env/bin:$PATH bash -c 'make verif';
 after_success:
 after_failure:
   # Upload files for debug.
-  - echo "Uploading up to 4 failure traces for debug" && for FILE in `ls /home/travis/build/stevehoover/warp-v/formal/checks/*/FAIL | head -n 4`; do curl --upload-file `echo $FILE | sed s/FAIL$//`engine_0/trace.vcd https://transfer.sh/`echo $FILE | sed 's/^.*\/\([^\/]*\)\/FAIL$/\1/'`_trace.vcd && echo; done
+  - echo "Uploading up to 4 failure traces for debug" && for FILE in `ls /home/travis/build/$BUILD_PATH/formal/checks/*/FAIL | head -n 4`; do curl --upload-file `echo $FILE | sed s/FAIL$//`engine_0/trace.vcd https://transfer.sh/`echo $FILE | sed 's/^.*\/\([^\/]*\)\/FAIL$/\1/'`_trace.vcd && echo; done
 after_script:
   # Report a message if we didn't use the latest commit of yosys.
   - if cmp -s yosys_latest_commit_id.txt env/yosys_commit_id.txt; then echo '******** Using the following cached yosys (https://github.com/cliffordwolf/yosys.git) commit ID which is not the latest. Consider clearing Travis cache. **********' && cat env/yosys_commit_id.txt && echo '**********'; fi

--- a/warp-v.tlv
+++ b/warp-v.tlv
@@ -2930,8 +2930,8 @@ m4_ifexpr(M4_CORE_CNT > 1, ['m4_include_lib(['https://raw.githubusercontent.com/
       m4_ifelse(M4_ISA, ['RISCV'], [''], ['m4_errprint(['M-ext supported for RISC-V only.']m4_new_line)'])
       /* verilator lint_off WIDTH */
       /* verilator lint_off CASEINCOMPLETE */   
-      m4_sv_include_url(['https:/']['/raw.githubusercontent.com/shivampotdar/warp-v/m_ext/muldiv/picorv32_pcpi_div.sv'])
-      m4_sv_include_url(['https:/']['/raw.githubusercontent.com/shivampotdar/warp-v/m_ext/muldiv/picorv32_pcpi_fast_mul.sv'])
+      m4_sv_include_url(['https:/']['/raw.githubusercontent.com/stevehoover/warp-v/master/muldiv/picorv32_pcpi_div.sv'])
+      m4_sv_include_url(['https:/']['/raw.githubusercontent.com/stevehoover/warp-v/master/muldiv/picorv32_pcpi_fast_mul.sv'])
       /* verilator lint_on WIDTH */
    '])
 


### PR DESCRIPTION
- Travis CI caching was broken in forks and PRs, this PR should fix that
- Verilog modules shall be included from master instead of forks (I am not sure if we can have env var type of mechanism here, prolly we can m4_define the required username/reponame and use it in all m4_includes. )