### PR TITLE
Enabling support for building warp-v with Fusesoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # makerchip-app backup files.
 *.bak
+build/
+*.conf

--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ cd warp-v
 ./init
 ```
 
+# Build with Fusesoc
+
+- Install edalize with sandpiper support
+ 
+```git clone https://github.com/shariethernet/edalize.git```
+
+``` cd edalize```
+
+```git checkout main```
+
+```pip3 install --user -r dev-requirements.txt```
+
+```pre-commit install```
+
+```pip3 install --user -e .```
+
+- Install fusesoc
+
+```pip install fusesoc```
+
+- Add warpv to fusesoc core library
+
+```fusesoc library add warpv .```
+
+- Build warp-v with Fusesoc (default configuration)
+
+```fusesoc run --target=sandpiper warpv```
+
+Warp-v can be configured according to your requirement by setting the `mxdef:` in `warp-v.core` 
+
+Note: In the the .core files use [] wherever you intend to use (). As Fusesoc parsers donot support (), the [] acts as a place holder and gets replaced by () later on.
 
 # Features
 

--- a/edalize_warpv.py
+++ b/edalize_warpv.py
@@ -1,0 +1,37 @@
+# Edalize script to build warp-v
+# python edalize_warpv.py
+from edalize import *
+import os
+work_root = 'build_multifile'
+
+files = [
+    {'name':os.path.relpath('warp-v.tlv',work_root),'file_type':'TLVerilogSource'}
+]
+
+tool_options = {
+		"sandpipersaas": {                  # Any arguments that needed to be passed to sandpiper-saas
+			"sandpiper_saas": [
+				"--bestsv", "--inlineGen", "--m4def 'm5_CONFIG_EXPR=m5_def(STANDARD_CONFIG,4-stage)'"
+			],
+            "output_file":"warp-v_rtl.sv", # One file name that ends with .v or .sv
+            "output_dir":"out1"  #,           # Optional
+            # "sandpiper_jar":" <Arguments to the sandpiper compiler>",
+            # "endpoint":"<Optional: URL for the compile service endpoint",
+            # "includes" :"List of include files to be used durung compilation "
+		}
+	}
+tool = 'sandpipersaas'
+parameters = {}
+edam = {
+    'files':files,
+    'name':'build_tlv1',
+    'parameters':parameters,
+    'tool_options':tool_options
+}
+
+backend = get_edatool(tool)(edam=edam, work_root=work_root)
+
+os.makedirs(work_root)
+backend.configure()
+backend.build()
+backend.run()

--- a/warp-v.core
+++ b/warp-v.core
@@ -7,16 +7,23 @@ filesets:
             - warp-v_config.tlv 
         file_type: TLVerilogSource
 
+    warpv:
+        files:
+            - warp-v.tlv
+        file_type: TLVerilogSource
+
 targets:
     sandpiper:
         default_tool: sandpipersaas
-        filesets: [warpv_config]
+        filesets: [warpv]
         tools:
             sandpipersaas:
                 sandpiper_saas:
-                    - --bestsv 
+                    - --bestsv
                     - --inlineGen
-                output_dir: 
+                mxdef:
+                    - m5_CONFIG_EXPR=m5_def[STANDARD_CONFIG,4-stage]
+                output_dir:
                     - "warpv_rtl"
                 output_file: 
                     - "warpv_rtl.sv"

--- a/warp-v.core
+++ b/warp-v.core
@@ -1,0 +1,23 @@
+CAPI=2:
+name : ::warpv:0
+
+filesets:
+    warpv_config:
+        files:
+            - warp-v_config.tlv 
+        file_type: TLVerilogSource
+
+targets:
+    sandpiper:
+        default_tool: sandpipersaas
+        filesets: [warpv_config]
+        tools:
+            sandpipersaas:
+                sandpiper_saas:
+                    - --bestsv 
+                    - --inlineGen
+                output_dir: 
+                    - "warpv_rtl"
+                output_file: 
+                    - "warpv_rtl.sv"
+        toplevel: [warpv]


### PR DESCRIPTION
This allows warp-v to be configured and built using fusesoc. A default configuration is provided in the fusesoc core file for reference. 